### PR TITLE
Support selecting Kube releases via command line flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,17 @@ end-to-end tests plus real world usage so it is guaranteed to work.
 Managing constraints and/or overrides by hand is a huge PITA so why not generate them?
 
 ## Usage
+See the [compatibility-matrix](https://github.com/kubernetes/client-go#compatibility-matrix) to get an overview, which `client-go` version works with what Kubernetes release.
 
-1. Download `Godeps.json` of a particular Kubernetes version you want to use. Pick a tag or a branch.
-For 1.12:
-```console
-curl -o Godeps.json https://raw.githubusercontent.com/kubernetes/kubernetes/release-1.12/Godeps/Godeps.json
-```
-2. Install the binary from this repository:
-```console
-go get -u github.com/ash2k/kubegodep2dep
-```
-3. Run the tool:
-```console
-kubegodep2dep -godep ./Godeps.json > Gopkg-new.toml
-```
-4. Add other dependencies that your project needs and use `dep ensure` to pull them all down.
+1. Install the binary from this repository:
+    ```console
+    go get -u github.com/ash2k/kubegodep2dep
+    ```
+
+1. Run the tool:
+    ```console
+    kubegodep2dep -kube-branch release-1.12 -client-go-branch release-9.0 > Gopkg-new.toml
+    ```
+    You can use `-godep` to pass another `Godep.json` other than the default file into the tool. URLs are supported as input, too.
+
+1. Add other dependencies that your project needs and use `dep ensure` to pull them all down.


### PR DESCRIPTION
First of all, I would like to thank you for this neat tool. It is a real time saver.

There was one thing that made it a little hard to use for me. I need to be able to simply select different Kubernetes/`client-go` versions, ideally via the command line. Also, to keep README instructions about this tool and how to use it as short as possible, I was wondering if `kubegodep2dep` could do the `Godeps.json` download for me so that it would only be one simple command to execute. I tried to keep the changes as compact as possible.

From the Git commit:
> Add two new command line flags to enable users to set `kube-branch` and
`client-go-branch` directly.
>
> Make `godep` flag optional by adding a routine to construct a URL to get
the `Godep.json` remotely from GitHub.

In my example, the call looks like this:
```bash
kubegodep2dep -kube-branch release-1.10 -client-go-branch release-7.0
```
During runtime, `kubegodep2dep` will use the provided input to download the `Godeps.json` from `https://raw.githubusercontent.com/kubernetes/kubernetes/<kube-branch>/Godeps/Godeps.json`.

Thanks in advance for your feedback.

