### PR TITLE
Add rule for gopher org domain

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,8 @@ func main() {
 			} else {
 				log.Fatalf("Unsupported syntax %s", d.ImportPath)
 			}
+		case parts[0] == "go4.org":
+			n = 1
 		default:
 			n = 2
 		}


### PR DESCRIPTION
Set length for `go4.org` to one since their projects start right at the root level of the domain.